### PR TITLE
[Untested] Change "<Hotkey>" to dynamically say action keyword #1

### DIFF
--- a/plugin/general_converter.py
+++ b/plugin/general_converter.py
@@ -23,7 +23,7 @@ class GenConvert(Flox):
             self.add_item(
                 title=_("General Converter"),
                 subtitle=_(
-                    "<Hotkey> <Amount> <Source unit - case sensitive> <Destination unit - case sensitive>"
+                    f"{query.ActionKeyword} <Amount> <Source unit - case sensitive> <Destination unit - case sensitive>"
                 ),
             )
             if self.settings.get("show_helper_text"):


### PR DESCRIPTION
THIS IS UNTESTED, because it's just a quick fix I made after developing my own plugin and realizing there's a better way.

Instead of saying `<Hotkey>`, dynamically get the hotkey (action keyword) and say that.